### PR TITLE
Extend Year Selection to Support 1900-2100 and Optimize Calendar Perf…

### DIFF
--- a/web.mjs
+++ b/web.mjs
@@ -130,26 +130,27 @@ async function fetchSpecialDayDescription(url, dayName) {
 
 // Populate dropdown selectors for month & year
 function populateMonthYearSelectors() {
-    const monthSelector = document.querySelector("#monthSelector");
-    const yearSelector = document.querySelector("#yearSelector");
+  const monthSelector = document.querySelector("#monthSelector");
+  const yearSelector = document.querySelector("#yearSelector");
 
-    monthSelector.innerHTML = monthNames.map((m, i) => `<option value="${i}">${m}</option>`).join('');
-    for (let y = 2000; y <= 2030; y++) {
-        yearSelector.innerHTML += `<option value="${y}">${y}</option>`;
-    }
+  // Populate month dropdown efficiently
+  monthSelector.innerHTML = monthNames.map((m, i) => `<option value="${i}">${m}</option>`).join('');
 
-    monthSelector.value = currentMonth;
-    yearSelector.value = currentYear;
+  // Efficient way to populate year dropdown
+  yearSelector.innerHTML = Array.from({ length: 201 }, (_, i) => `<option value="${1900 + i}">${1900 + i}</option>`).join('');
 
-    monthSelector.addEventListener("change", (e) => {
-        currentMonth = parseInt(e.target.value);
-        updateCalendar();
-    });
+  monthSelector.value = currentMonth;
+  yearSelector.value = currentYear;
 
-    yearSelector.addEventListener("change", (e) => {
-        currentYear = parseInt(e.target.value);
-        updateCalendar();
-    });
+  monthSelector.addEventListener("change", (e) => {
+      currentMonth = parseInt(e.target.value);
+      updateCalendar();
+  });
+
+  yearSelector.addEventListener("change", (e) => {
+      currentYear = parseInt(e.target.value);
+      updateCalendar();
+  });
 }
 
 // Initialize everything when the page loads


### PR DESCRIPTION
 What does this PR do?
- Extends the calendar’s year selection range from **1900 to 2100** to meet project requirements.
- Optimizes year dropdown population using `Array.from()` instead of multiple DOM updates.
- Improves first-day calculation to prevent alignment errors.
- Fixes potential parsing issues with `Date()` by using `monthNames.indexOf()`.
- Ensures compatibility with older years (before 1970) to avoid unexpected behavior.

 How was this tested?
- Navigated to various years (e.g., 1900, 1950, 2024, 2050) to ensure the calendar renders correctly.
- Verified commemorative days appear accurately for all years.
- Tested dropdown selection performance and ensured smooth updates.

Screenshots (if applicable)
_If necessary, add screenshots to show the improved functionality._

@leiliheidarishizari  and @AFatmaa please Checklist before merging and let me know:
- [x] Year selection works from **1900 to 2100**.
- [x] Calendar updates correctly when changing the month/year.
- [x] Special days are displayed properly in all years.
- [x] Code is optimized for performance.